### PR TITLE
Fix read tuple as int bug in data preprocess

### DIFF
--- a/pykt/preprocess/aaai2022_competition.py
+++ b/pykt/preprocess/aaai2022_competition.py
@@ -28,7 +28,7 @@ def read_data_from_csv(read_file, write_file, dq2c):
     ins, us, qs, cs, avgins, avgcq, na = sta_infos(df, KEYS, stares)
     print(f"after drop interaction num: {ins}, user num: {us}, question num: {qs}, concept num: {cs}, avg(ins) per s: {avgins}, avg(c) per q: {avgcq}, na: {na}")
     
-    ui_df = df.groupby(['stu_id'], sort=False)
+    ui_df = df.groupby('stu_id', sort=False)
 
     user_inters = []
     for ui in ui_df:

--- a/pykt/preprocess/algebra2005_preprocess.py
+++ b/pykt/preprocess/algebra2005_preprocess.py
@@ -27,7 +27,7 @@ def read_data_from_csv(read_file, write_file):
     print(f"after drop interaction num: {ins}, user num: {us}, question num: {qs}, concept num: {cs}, avg(ins) per s: {avgins}, avg(c) per q: {avgcq}, na: {na}")
 
     data = []
-    ui_df = df.groupby(['Anon Student Id'], sort=False)
+    ui_df = df.groupby('Anon Student Id', sort=False)
 
     for ui in ui_df:
         u, curdf = ui[0], ui[1]

--- a/pykt/preprocess/assist2009_preprocess.py
+++ b/pykt/preprocess/assist2009_preprocess.py
@@ -19,7 +19,7 @@ def read_data_from_csv(read_file, write_file):
     ins, us, qs, cs, avgins, avgcq, na = sta_infos(_df, KEYS, stares)
     print(f"after drop interaction num: {ins}, user num: {us}, question num: {qs}, concept num: {cs}, avg(ins) per s: {avgins}, avg(c) per q: {avgcq}, na: {na}")
 
-    ui_df = _df.groupby(['user_id'], sort=False)
+    ui_df = _df.groupby('user_id', sort=False)
 
     user_inters = []
     for ui in ui_df:

--- a/pykt/preprocess/assist2012_preprocess.py
+++ b/pykt/preprocess/assist2012_preprocess.py
@@ -30,7 +30,7 @@ def read_data_from_csv(read_file, write_file):
 
 
     user_inters = []
-    for user, group in df.groupby(['user_id'], sort=False):
+    for user, group in df.groupby('user_id', sort=False):
         group = group.sort_values(['start_timestamp','tmp_index'])
         seq_skills = group['skill_id'].tolist()
         seq_ans = group['correct'].tolist()

--- a/pykt/preprocess/assist2015_preprocess.py
+++ b/pykt/preprocess/assist2015_preprocess.py
@@ -20,7 +20,7 @@ def read_data_from_csv(read_file, write_file):
     ins, us, qs, cs, avgins, avgcq, na = sta_infos(df, KEYS, stares)
     print(f"after drop interaction num: {ins}, user num: {us}, question num: {qs}, concept num: {cs}, avg(ins) per s: {avgins}, avg(c) per q: {avgcq}, na: {na}")
     
-    ui_df = df.groupby(['user_id'], sort=False)
+    ui_df = df.groupby('user_id', sort=False)
 
     user_inters = []
     for ui in ui_df:

--- a/pykt/preprocess/assist2017_preprocess.py
+++ b/pykt/preprocess/assist2017_preprocess.py
@@ -23,7 +23,7 @@ def read_data_from_csv(read_file, write_file):
     print(f"after drop interaction num: {ins}, user num: {us}, question num: {qs}, concept num: {cs}, avg(ins) per s: {avgins}, avg(c) per q: {avgcq}, na: {na}")
 
     df2 = df[["index", "studentId", "problemId", "skill", "correct", "timeTaken", "startTime"]]
-    ui_df = df2.groupby(['studentId'], sort=False)
+    ui_df = df2.groupby('studentId', sort=False)
 
     user_inter = []
     for ui in ui_df:

--- a/pykt/preprocess/ednet_preprocess.py
+++ b/pykt/preprocess/ednet_preprocess.py
@@ -66,7 +66,7 @@ def read_data_from_csv(read_file, write_file,dataset_name=None):
     
     co.to_csv(os.path.join(read_file, 'ednet_sample_process.csv'), index=False)
     
-    ui_df = co.groupby(['user_id'], sort=False)
+    ui_df = co.groupby('user_id', sort=False)
 
     user_inters = []
     for ui in tqdm(ui_df):

--- a/pykt/preprocess/junyi2015_preprocess.py
+++ b/pykt/preprocess/junyi2015_preprocess.py
@@ -44,7 +44,7 @@ def read_data_from_csv(read_file, write_file, dq2c):
     problems = usedf.exercise.unique()
     print(f"usedf: {usedf.shape}, uids: {len(uids)}, problems: {len(problems)}")
 
-    ui_df = usedf.groupby(['user_id'], sort=False)
+    ui_df = usedf.groupby('user_id', sort=False)
 
     for ui in ui_df:
         uid, curdf = ui[0], ui[1]

--- a/pykt/preprocess/poj_preprocess.py
+++ b/pykt/preprocess/poj_preprocess.py
@@ -21,7 +21,7 @@ def read_data_from_csv(read_file, write_file):
     print(f"after drop interaction num: {ins}, user num: {us}, question num: {qs}, concept num: {cs}, avg(ins) per s: {avgins}, avg(c) per q: {avgcq}, na: {na}")
     
     data = []
-    ui_df = df.groupby(['User'], sort=False)
+    ui_df = df.groupby('User', sort=False)
 
     for ui in ui_df:
         uid, curdf = ui[0], ui[1]

--- a/pykt/preprocess/slepemapy_preprocess.py
+++ b/pykt/preprocess/slepemapy_preprocess.py
@@ -19,7 +19,7 @@ def read_data_from_csv(read_file, write_file):
     print(f"after drop interaction num: {ins}, user num: {us}, question num: {qs}, concept num: {cs}, avg(ins) per s: {avgins}, avg(c) per q: {avgcq}, na: {na}")
 
     data = []
-    ui_df = df.groupby(['user'], sort=False)
+    ui_df = df.groupby('user', sort=False)
 
     for ui in ui_df:
         uid, curdf = ui[0], ui[1]


### PR DESCRIPTION
Pandas update: `DataFrame.groupby()` always returns a tuple if a list is supplied.

_Pandas_ version 1.5.3 warning which has been implemented:
> FutureWarning: In a future version of pandas, a length 1 tuple will be returned when iterating over a groupby with a grouper equal to a list of length 1. Don't supply a list with a single grouper to avoid this warning.