### PR TITLE
fixing wrong argument assignment in wandb_predict.py

### DIFF
--- a/examples/wandb_predict.py
+++ b/examples/wandb_predict.py
@@ -77,7 +77,7 @@ def main(params):
     if model.model_name == "rkt":
         testauc, testacc = evaluate(model, test_loader, model_name, rel, save_test_path)
     else:
-        testauc, testacc = evaluate(model, test_loader, model_name, save_test_path)
+        testauc, testacc = evaluate(model, test_loader, model_name, None, save_test_path)
     print(f"testauc: {testauc}, testacc: {testacc}")
 
     window_testauc, window_testacc = -1, -1


### PR DESCRIPTION
The current version causes skipping the 'save_test_path' argument, thereby (incorrectly) skipping saving the output file