### PR TITLE
fix: ensure tensor is moved to the correct device

### DIFF
--- a/pykt/models/atdkt.py
+++ b/pykt/models/atdkt.py
@@ -132,7 +132,7 @@ class ATDKT(Module):
         emb_type = self.emb_type
         if emb_type.startswith("qid"):
             x = c + self.num_c * r
-            xemb = self.interaction_emb(x)
+            xemb = self.interaction_emb(x.to(device))
         rpreds, qh = None, None
         if emb_type == "qid":
             h, _ = self.lstm_layer(xemb)


### PR DESCRIPTION
Fix the following error.
<img width="993" alt="image" src="https://github.com/user-attachments/assets/48782f13-f6d8-4900-b995-7dfa210f1591" />
