### PR TITLE
Fix KeyError 'num_rgap' in wandb_predict.py for fa_kt

### DIFF
--- a/examples/wandb_predict.py
+++ b/examples/wandb_predict.py
@@ -40,7 +40,7 @@ def main(params):
         curconfig = copy.deepcopy(json.load(fin))
         data_config = curconfig[dataset_name]
         data_config["dataset_name"] = dataset_name
-        if model_name in ["dkt_forget", "bakt_time", "mtkt"]:
+        if model_name in ["dkt_forget", "bakt_time", "fa_kt", "mtkt"]:
             data_config["num_rgap"] = config["data_config"]["num_rgap"]
             data_config["num_sgap"] = config["data_config"]["num_sgap"]
             data_config["num_pcount"] = config["data_config"]["num_pcount"]


### PR DESCRIPTION
Add fa_kt to the same branch as dkt_forget / bakt_time / mtkt so prediction can recover time-gap fields saved during training.