### PR TITLE
Document required questions_concepts.pt file for DenoiseKT

### DIFF
--- a/examples/wandb_denoisekt_train.py
+++ b/examples/wandb_denoisekt_train.py
@@ -1,6 +1,12 @@
 import argparse
 from wandb_train import main
 
+# NOTE:
+# DenoiseKT requires a sparse question-concept adjacency tensor file
+# `<dpath>/questions_concepts.pt` under the dataset directory.
+# Download the generation script from:
+# https://drive.google.com/file/d/15R1RNvV4NmwsEoYUyJwTwGXCsK_ODbLd/view?usp=sharing
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--dataset_name", type=str, default="assist2009")

--- a/pykt/models/denoisekt.py
+++ b/pykt/models/denoisekt.py
@@ -64,7 +64,17 @@ class DenoiseKTNet(nn.Module):
                 self.difficult_param = nn.Embedding(self.num_q+1, embed_l) 
             
 
+        # The sparse question-concept adjacency tensor `questions_concepts.pt`
+        # is required under <dpath> for DenoiseKT. The generation script can
+        # be downloaded from:
+        # https://drive.google.com/file/d/15R1RNvV4NmwsEoYUyJwTwGXCsK_ODbLd/view?usp=sharing
         qs_cs_path = dpath + '/questions_concepts.pt'
+        if not os.path.exists(qs_cs_path):
+            raise FileNotFoundError(
+                f"DenoiseKT requires `{qs_cs_path}` (sparse question-concept "
+                f"adjacency tensor). Generate it with the script at "
+                f"https://drive.google.com/file/d/15R1RNvV4NmwsEoYUyJwTwGXCsK_ODbLd/view?usp=sharing"
+            )
         self.matrix = torch.load(qs_cs_path).to(device)
         
 


### PR DESCRIPTION
- Add a comment and FileNotFoundError with the Google Drive link for the generation script in pykt/models/denoisekt.py, so users get a clear hint instead of a generic 'No such file or directory' from torch.load.
- Add the same link as a top-of-file note in examples/wandb_denoisekt_train.py.
